### PR TITLE
Fix linux build and #212

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies += "com.fasterxml.jackson.module" % "jackson-module-scala_2.
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 
-libraryDependencies += "org.scala-lang.modules" % "scala-swing_2.12" % "2.0.2"
+libraryDependencies += "org.scala-lang.modules" % "scala-swing_2.12" % "2.0.3"
 
 //libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
 

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -2,7 +2,7 @@ name := "quanto"
 
 version := "1.0"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.6"
 
 scalacOptions ++= Seq("-feature", "-language:implicitConversions")
 
@@ -14,19 +14,19 @@ fork := true
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
  
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.9" withSources() withJavadoc()
+libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.5.12" withSources() withJavadoc()
 
-libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.9.4"
+libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % "2.9.5"
 
-libraryDependencies += "com.fasterxml.jackson.module" % "jackson-module-scala_2.12" % "2.9.4"
+libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.5"
 
 //libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1" % "test"
 
 //libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.4"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
-libraryDependencies += "org.scala-lang.modules" % "scala-swing_2.12" % "2.0.3"
+libraryDependencies += "org.scala-lang.modules" %% "scala-swing" % "2.0.3"
 
 //libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
 

--- a/scala/dist/mk-linux-generic.sh
+++ b/scala/dist/mk-linux-generic.sh
@@ -5,6 +5,11 @@
 
 BUNDLE=target/QuantoDerive
 
+# Pre-build cleanup, so we know we're building in a consistent environment.
+sbt clean
+rm -r ../core/heaps/* 
+rm -r $BUNDLE/*
+
 # Rebuild the core heap
 echo Rebuilding the core heap...
 mkdir -p ../core/heaps
@@ -23,7 +28,8 @@ sbt package
 
 echo Including binaries...
 cp -f dist/linux-dist/quanto-derive.sh $BUNDLE/
-cp -f dist/linux-dist/polybin dist/linux-dist/poly $BUNDLE/bin
+cp -f dist/linux-dist/polybin $BUNDLE/bin
+cp -f dist/linux-dist/poly $BUNDLE/bin
 cp -f dist/linux-dist/libpolyml.so.4 $BUNDLE/bin
 
 echo Including heap...

--- a/scala/dist/mk-linux-generic.sh
+++ b/scala/dist/mk-linux-generic.sh
@@ -7,6 +7,7 @@ BUNDLE=target/QuantoDerive
 
 # Rebuild the core heap
 echo Rebuilding the core heap...
+mkdir -p ../core/heaps
 (cd ../core; ../scala/dist/linux-dist/poly --use build_heap.ML)
 
 
@@ -36,7 +37,8 @@ echo Including jars...
 cp -f lib_managed/jars/*/*/akka-actor*.jar $BUNDLE/jars
 cp -f lib_managed/jars/*/*/scala-library*.jar $BUNDLE/jars
 cp -f lib_managed/jars/*/*/scala-swing*.jar $BUNDLE/jars
-cp -f lib_managed/jars/*/*/jackson-core*.jar $BUNDLE/jars
+cp -f lib_managed/bundles/*/*/scala-parser-combinators*.jar $BUNDLE/jars
+cp -f lib_managed/bundles/*/*/jackson-core*.jar $BUNDLE/jars
 cp -f lib_managed/bundles/*/*/config*.jar $BUNDLE/jars
 
 # grab local dependences


### PR DESCRIPTION
Bumps the version number of scala-swing in scala/build.sbt to fix #212 , and adjusts the Linux buildscript to work with current Scala on a clean install.