### PR TITLE
 Bumped sbt-assembly for Java 10 compatibility 

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,5 +10,5 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("org.ensime" % "ensime-sbt-cmd" % "0.1.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
 


### PR DESCRIPTION
Old version of sbt-assembly didn't recognize 10 as an existing Java version number during build, crashing the build process by assertion. Bumping sbt version and sbt-assembly version fixes that. Now both builds and runs successfully on both Java 8 and Java 10.